### PR TITLE
Moved Device properties to main script and included sample for overriding them.

### DIFF
--- a/Ant-Build-Script/build.xml
+++ b/Ant-Build-Script/build.xml
@@ -27,7 +27,13 @@
 	<!-- Fail the build on JSLint, JSHint, CSSLint errors -->
 	<property name="lintfail" value="false"/>
 	
-	<!-- Include the Targets  -->
+	<!-- Include the Properties and Targets  -->
+	<!-- 
+	The ${ant.home} variable will only work if running the Ant included in this repository. On Mac, which uses its own Ant, set a direct file path here.
+	
+	The buildProperties.xml file is optional but allows you to separate out certain settings, like passwords.
+	-->
+	<!-- <include file="${ant.home}/../buildProperties.xml" /> -->
 	<include file="${ant.home}/../buildTasks.xml" />
 
 	<!-- Default Build - Change as needed to the sdk and build properties you want:
@@ -58,16 +64,6 @@
 	- test, prod, beta to load the matching build created above
 	-->
 	<target name="build" depends="build.native.prod,build.deploy.native.sim.prod"></target>
-
-	<!-- Set the details of the device or simulator for deployment -->
-	<!-- For BB10 device -->
-	<property name="device.native.ip" value="169.254.0.1"/>
-	<property name="device.native.pw" value="" />
-	<!-- For Tablet device -->
-	<property name="device.air.ip" value="169.254.0.2"/>
-	<property name="device.air.pw" value="" />
-	<!-- For BBOS Java device (only password is needed) -->
-	<property name="device.java.pw" value="" />
 
 	<!-- Add additional Targets here -->
 	<target name="example" depends=""></target>

--- a/Ant-Build-Script/tools/buildProperties.xml
+++ b/Ant-Build-Script/tools/buildProperties.xml
@@ -1,0 +1,21 @@
+<project>
+	<!-- Build Properties Overrides -->
+	
+	<!-- 
+	Any properties that exist here will override the ones defined
+	in buildTasks.xml, as long as this file is included first.
+	-->
+
+	<!-- Code Signing Password -->
+	<property name="sign.pw" value="*****"/>
+
+	<!-- Set the details of the device or simulator for deployment -->
+	<!-- For BB10 device -->
+	<property name="device.native.ip" value="169.254.0.1"/>
+	<property name="device.native.pw" value="" />
+	<!-- For Tablet device -->
+	<property name="device.air.ip" value="169.254.0.5"/>
+	<property name="device.air.pw" value="" />
+	<!-- For BBOS Java device (only password is needed) -->
+	<property name="device.java.pw" value="" />
+</project>

--- a/Ant-Build-Script/tools/buildTasks.xml
+++ b/Ant-Build-Script/tools/buildTasks.xml
@@ -17,8 +17,18 @@
  *
  -->
 <project basedir="." name="build">
-	<!-- Code Signing Password -->
+	<!-- Code Signing Key Password -->
 	<property name="sign.pw" value="********"/>
+
+	<!-- Set the details of the device or simulator for deployment -->
+	<!-- For BB10 device -->
+	<property name="device.native.ip" value="169.254.0.1"/>
+	<property name="device.native.pw" value="" />
+	<!-- For Tablet device -->
+	<property name="device.air.ip" value="169.254.0.5"/>
+	<property name="device.air.pw" value="" />
+	<!-- For BBOS Java device (only password is needed) -->
+	<property name="device.java.pw" value="" />
 
 	<!-- Files to exclude from zip -->
 	<property name="file.excludes" value="build/ bin/ .project .externalToolBuilders/ build.xml build.number"/>


### PR DESCRIPTION
Device passwords and IPs change pretty rarely in practice so keeping them in the main file is okay.

Included a sample to show how to override them with a separate file, which is helpful. This means that build.xml files can now be included safely in Git repositories too.
